### PR TITLE
refactor(convert): remove heading numbering

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -61,9 +61,8 @@ fn convert_book_item(ctx: &RenderContext, item: &BookItem) -> Result<String, any
       Some(number) => {
         writeln!(
           book_item_str,
-          "{} {} {} <{}.html>",
+          "{} {} <{}.html>",
           "=".repeat(number.len()),
-          number,
           ch.name,
           label,
         )?;


### PR DESCRIPTION
标题编号应该由 Typst 实现，在模板文件中添加 `#set heading(numbering: "1.1.")` 即可实现。